### PR TITLE
fix: `generate-build-number` sometimes generates build numbers longer than 10 characters

### DIFF
--- a/build-tools.py
+++ b/build-tools.py
@@ -152,7 +152,9 @@ def command_verify_notarized_zip(options):
 @command("generate-build-number", help="synthesize a build number (YYmmddHHMM + 8 digit integer representation of a 6 digit Git SHA")
 def command_generate_build_number(options):
     utc_time = datetime.datetime.utcnow()
-    git_sha = subprocess.check_output(["git", "rev-parse", "--short=6", "HEAD"]).decode("utf-8").strip()
+    # Unhelpfully, the '--short=length' option guarantees to give an object name _no shorter_ than the requested length
+    # will happily, on occasion, return one that's longer, meaning we have to limit this to 6 characters ourselves.
+    git_sha = subprocess.check_output(["git", "rev-parse", "--short=6", "HEAD"]).decode("utf-8").strip()[:6]
     git_sha_int = int(git_sha, 16)
     build_number = f"{utc_time.strftime('%y%m%d%H%M')}{git_sha_int:08}"
     print(build_number)


### PR DESCRIPTION
Unhelpfully, the `git rev-parse --short=length` option guarantees to give an object name _no shorter_ than the requested length will happily, on occasion, return one that's longer, meaning we have to limit this to 6 characters ourselves.