### PR TITLE
fix: 📌 Require fastcommand 0.2.0 or later

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
   {name = "Jason Morley", email = "hello@jbmorley.co.uk"}
 ]
 dependencies = [
-  "fastcommand",
+  "fastcommand>=0.2.0",
   "requests",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
We require 0.2 or above to get the auto-completion support.