### PR TITLE
fix: 🤫 Artifacts without metadata should not stop metadata promotion

### DIFF
--- a/src/build_tools/build_tools.py
+++ b/src/build_tools/build_tools.py
@@ -372,7 +372,7 @@ def command_github_releases(options):
         # Promote the version number, build number, sha, and date if all artifacts agree.
         if len(artifacts) > 0:
             for key in ["version", "build_number", "sha_short", "date", "time_zone", "commit_url"]:
-                values = {artifact.get(key, None) for artifact in artifacts}
+                values = {artifact[key] for artifact in artifacts if key in artifact}
                 value = values.pop() if len(values) == 1 else None
                 if value is None:
                     continue


### PR DESCRIPTION
This change ensures that artifacts that are missing metadata keys (`version`, `build_number`, `sha_short`, etc) do not prevent the values for these keys from other artifacts getting promoted the the release itself. Without this unversioned downloads would stop top-level releases getting versions.
